### PR TITLE
1.1 apis

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -4,6 +4,45 @@
 
 function _doFdc3(){
 
+/**
+*  the Listener class 
+*/
+class Listener {
+    constructor(){
+
+
+    }
+
+    unsubscribe(){
+        
+    }
+}
+
+/**
+ * the Channel class 
+ */
+class Channel {
+    constructor(id, type, displayMetadata){
+        this.id = id;
+        this.type = type;
+        this.displayMetadata = displayMetadata;
+    }
+
+    broadcast(context){
+
+    }
+
+    getCurrentContext(contextType){
+        return new Promise(async (resolve, reject) => {
+
+        });
+    }
+
+    addContextListener(handler) {
+
+    }
+}
+
 const wireMethod = (method, detail, isVoid) => {
     const ts = Date.now();
     const eventId = `${method}_${ts}`;

--- a/src/api.js
+++ b/src/api.js
@@ -24,7 +24,7 @@ const guid = () => {
     
     return `${gen(2)}-${gen()}-${gen()}-${gen()}-${gen(3)}`;
     };
-    
+
 /**
 *  the Listener class 
 */
@@ -63,16 +63,23 @@ class Channel {
     }
 
     broadcast(context){
-
+        wireMethod("broadcast", {context:context,channel:this.id}, true);
     }
 
     getCurrentContext(contextType){
-        return new Promise(async (resolve, reject) => {
-
-        });
+        return wireMethod("getCurrentContext",{channel:this.id});
     }
 
-    addContextListener(handler) {
+    addContextListener(listener) {
+        const listenerId = guid();
+        _contextListeners[listenerId] = listener;
+        document.dispatchEvent(new CustomEvent('FDC3:addContextListener', {
+            detail:{
+                id:listenerId, 
+                channel:this.id
+            }
+        }));
+        return new Listener("context",listenerId);
     }
 }
 
@@ -160,7 +167,10 @@ window.fdc3 = {
     getSystemChannels: function(){
         return new Promise((resolve, reject) => {
             document.addEventListener("FDC3:returnSystemChannels",evt =>{
-                resolve(evt.detail.data);
+                let channels = evt.detail.data.map(c => {
+                    return new Channel(c.id,"system",c.displayMetadata);
+                });
+                resolve(channels);
             }, {once : true});
             document.dispatchEvent(new CustomEvent('FDC3:getSystemChannels', {
   

--- a/src/background.js
+++ b/src/background.js
@@ -116,10 +116,12 @@ chrome.runtime.onConnect.addListener( async function(port) {
                     error:err};
             }
             //post the return message back to the content script
-            port.postMessage({
-                    topic:msg.data.eventId,
-                    data:r
-            })
+            if (msg.data && msg.data.eventId){
+                port.postMessage({
+                        topic:msg.data.eventId,
+                        data:r
+                })
+            }
         }
         else {
             console.log(`no listener found for message topic '${msg.topic}'`);   

--- a/src/components/channel-picker.js
+++ b/src/components/channel-picker.js
@@ -83,7 +83,7 @@ class FDC3ChannelPicker extends HTMLElement {
       shadow.appendChild(wrapper);
 
           const target = wrapper;
-        let defChan = [{id:"default", "visualIdentity":{name:"Default", color:"#ccc",color2:"#999"}}];
+        let defChan = [{id:"default", "displayMetadata":{name:"Default", color:"#ccc",color2:"#999"}}];
        this.channels = defChan.concat(systemChannels ? systemChannels : []);
        console.log(this.channels);
        
@@ -94,8 +94,8 @@ class FDC3ChannelPicker extends HTMLElement {
                 let revert = this.revertItem.bind(this);
                 ch.id = channel.id;
                 ch.className = "picker-item";
-                ch.title = channel.visualIdentity.name;
-                ch.style.backgroundColor = channel.visualIdentity.color;
+                ch.title = channel.displayMetadata.name;
+                ch.style.backgroundColor = channel.displayMetadata.color;
               
                 target.appendChild(ch);
                 ch.addEventListener("click",select);
@@ -119,7 +119,7 @@ class FDC3ChannelPicker extends HTMLElement {
                 chrome.browserAction.setBadgeText({text:"+",
                                     tabId:sender.tab.id});
                 let selectedChannel = this.channels.find(chan => {return chan.id === request.channel});
-                chrome.browserAction.setBadgeBackgroundColor({color:selectedChannel.visualIdentity.color,
+                chrome.browserAction.setBadgeBackgroundColor({color:selectedChannel.displayMetadata.color,
                                 tabId:sender.tab.id});
                 }
 
@@ -143,8 +143,8 @@ class FDC3ChannelPicker extends HTMLElement {
             joinChannel(selection);
                 this.toggle();
                 let selectedChannel = this.channels.find(chan => {return chan.id === selection});
-                if (selectedChannel && selectedChannel.visualIdentity){
-                    picker.style.borderColor = selectedChannel.visualIdentity.color;
+                if (selectedChannel && selectedChannel.displayMetadata){
+                    picker.style.borderColor = selectedChannel.displayMetadata.color;
                 }
         }
     }
@@ -152,13 +152,13 @@ class FDC3ChannelPicker extends HTMLElement {
     hoverItem(ev){
         let selection = ev.target.id;
         let selectedChannel = this.channels.find(chan => {return chan.id === selection});
-        ev.target.style.backgroundColor = selectedChannel.visualIdentity.color2;
+        ev.target.style.backgroundColor = selectedChannel.displayMetadata.color2;
     }
 
     revertItem(ev){
         let selection = ev.target.id;
         let selectedChannel = this.channels.find(chan => {return chan.id === selection});
-        ev.target.style.backgroundColor = selectedChannel.visualIdentity.color;
+        ev.target.style.backgroundColor = selectedChannel.displayMetadata.color;
     }
     toggle() {
       let root = this.shadowRoot;

--- a/src/content.js
+++ b/src/content.js
@@ -93,7 +93,7 @@ const wireTopic = (topic, config) => {
 };
  
  //listen for FDC3 events
- const topics = ["open","raiseIntent","addContextListener","addIntentListener","findIntent","findIntentsByContext","getCurrentContext"];
+ const topics = ["open","raiseIntent","addContextListener","addIntentListener","findIntent","findIntentsByContext","getCurrentContext","getSystemChannels","getOrCreateChannel"];
  topics.forEach(t => {wireTopic(t);});
  //set the custom ones...
  wireTopic("joinChannel",{cb:(e) => { currentChannel = e.detail.channel;}});
@@ -109,9 +109,9 @@ document.addEventListener("FDC3:resolver-close", e => {
 });
 
 //systemchannels are constant and we don't have to go to the background script, so handle directly
-document.addEventListener("FDC3:getSystemChannels", e => {
-    document.dispatchEvent(new CustomEvent("FDC3:returnSystemChannels",{detail:{data:channels} } ));
-});
+//document.addEventListener("FDC3:getSystemChannels", e => {
+ //   document.dispatchEvent(new CustomEvent("FDC3:returnSystemChannels",{detail:{data:channels} } ));
+//});
 
 
 port.onMessage.addListener(msg => {

--- a/src/content.js
+++ b/src/content.js
@@ -93,7 +93,7 @@ const wireTopic = (topic, config) => {
 };
  
  //listen for FDC3 events
- const topics = ["open","raiseIntent","addContextListener","addIntentListener","findIntent","findIntentsByContext"];
+ const topics = ["open","raiseIntent","addContextListener","addIntentListener","findIntent","findIntentsByContext","getCurrentContext"];
  topics.forEach(t => {wireTopic(t);});
  //set the custom ones...
  wireTopic("joinChannel",{cb:(e) => { currentChannel = e.detail.channel;}});

--- a/src/system-channels.js
+++ b/src/system-channels.js
@@ -2,27 +2,27 @@
  * metadata for the system channels 
  */
 export default[
-    {"id":"red","type":"system","visualIdentity":
+    {"id":"red","type":"system","displayMetadata":
         {"color":"#da2d2d",
         "color2":"#9d0b0b",
         "name":"Red"}},
-    {"id":"orange","type":"system","visualIdentity":
+    {"id":"orange","type":"system","displayMetadata":
         {"color":"#eb8242",
         "color2":"#e25822",
         "name":"Orange"}},
-    {"id":"yellow","type":"system","visualIdentity":
+    {"id":"yellow","type":"system","displayMetadata":
         {"color":"#f6da63",
         "color2":"#e3c878",
         "name":"Yellow"}},
-    {"id":"green","type":"system","visualIdentity":
+    {"id":"green","type":"system","displayMetadata":
         {"color":"#42b883",
         "color2":"#347474",
         "name":"Green"}},
-    {"id":"blue","type":"system","visualIdentity":
+    {"id":"blue","type":"system","displayMetadata":
         {"color":"#1089ff",
         "color2":"#505BDA",
         "name":"Blue"}},
-    {"id":"purple","type":"system","visualIdentity":
+    {"id":"purple","type":"system","displayMetadata":
         {"color":"#C355F5",
         "color2":"#AA26DA",
         "name":"Purple"}}


### PR DESCRIPTION
Added more 1.1 API support.  Including:

- Channel class with support for `addContextListener`, `broadcast`, and `getCurrentContext` on a specific channel
- App Channels and creating with the `getOrCreateChannel` method
- optional `contextType` argument on `addContextListener` and `getCurrentContext` methods
 